### PR TITLE
set-up delete-product feature

### DIFF
--- a/crm/webapp/templates/product.html
+++ b/crm/webapp/templates/product.html
@@ -16,10 +16,11 @@
                 <table class="table table-hover">
                     <thead class="table-warning">
                         <tr>
-                            <th scope="col">Id</th>
+                            <th scope="col">#</th>
                             <th scope="col">Product Name</th>
                             <th scope="col">Price</th>
                             <th scope="col">Purchase Date</th>
+                            <th scope="col">Action</th> <!-- New column -->
                         </tr>
                     </thead>
                     <tbody class="table-striped">
@@ -29,6 +30,12 @@
                                 <td>{{ product.product_name }}</td>
                                 <td>{{ product.price }}</td>
                                 <td>{{ product.date }}</td>
+                                <td>
+                                    <a href="{% url 'delete_product' product.id %}" class="btn btn-danger btn-sm"
+                                       onclick="return confirm('Are you sure you want to delete this product?');">
+                                        Delete
+                                    </a>
+                                </td>
                             </tr>
                         {% endfor %}
                     </tbody>

--- a/crm/webapp/urls.py
+++ b/crm/webapp/urls.py
@@ -12,5 +12,7 @@ urlpatterns = [
     path('client_update/<int:pk>', views.client_update, name='client_update'),
     path('client/product/<int:client_pk>/', views.product, name='product'),
     path('client/new_product/<int:client_pk>/', views.new_product, name='new_product'),
-    path('search_client/', views.search_client, name='search_client')
+    path('search_client/', views.search_client, name='search_client'),
+    path('client/delete_product/<int:product_pk>/', views.delete_product, name='delete_product'),
+
 ]

--- a/crm/webapp/views.py
+++ b/crm/webapp/views.py
@@ -156,3 +156,16 @@ def search_client(request):
     return render(request, 'search_client.html', {'results': results, 'query': query})
     
             
+# for deleting a product
+from .models import Product
+
+def delete_product(request, product_pk):
+    if request.user.is_authenticated:
+        product = get_object_or_404(Product, pk=product_pk)
+        client_id = product.client.id
+        product.delete()
+        messages.success(request, "Product deleted successfully")
+        return redirect('product', client_pk=client_id)
+    else:
+        messages.error(request, "You need to login to delete a product")
+        return redirect('home')


### PR DESCRIPTION
#28 
 feat: Implement delete functionality for client-specific products
Description:
This PR adds the ability for authenticated users to delete products associated with a specific client. It includes a delete action in the UI and the corresponding backend route, logic, and messaging.

🔧 Changes Implemented:
🗑️ Product Deletion View

Added delete_product view in views.py using get_object_or_404.

Ensures only authenticated users can delete products.

Product is removed from the database, and the user is redirected back to the related client's product list page.

🌐 New Route

Added URL pattern:

pgsql
Copy
Edit
path('client/delete_product/<int:product_pk>/', views.delete_product, name='delete_product')
🖥️ Updated Template (product.html)

Added Action column to the product list table.

Included a "Delete" button next to each product with a confirmation dialog (onclick="return confirm(...)").

📦 Model Import

Imported Product model in views.py to enable deletion.

🔐 Access Control
Only authenticated users can delete products.

Unauthorized access redirects the user to the home page with an error message.

Delete buttons only appear in the template for logged-in users.

💬 Flash Messages
Success: “Product deleted successfully”

Error: “You need to login to delete a product”

✅ Checklist
 Delete functionality tested and working

 Secure access checks implemented

 Flash messages display correctly

 Database integrity maintained

 UI confirmation before deletion

📌 Future Improvements
Add soft-delete functionality (status flag) instead of permanent deletion

Role-based access for finer control (e.g., admin-only delete)

Modal confirmation dialog instead of browser alert