### PR TITLE
home-page link fixed

### DIFF
--- a/crm/webapp/templates/navbar.html
+++ b/crm/webapp/templates/navbar.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container-fluid">
-        <a class="navbar-brand" href="#">CRM</a>
+        <a class="navbar-brand" href="/">CRM</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
             aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
PR Title: Fix: Navbar Brand Link to Home Page (#33)
Description
This PR addresses issue #33 by adding a direct link to the application's home page (/) on the navbar brand. Previously, clicking the "CRM" text in the navbar did not navigate users to the home page, which was inconsistent with common web navigation patterns and user expectations.

Changes Made
navbar.html: Added href="/"  to the <a> tag within the <a class="navbar-brand" href="#">CRM</a>element. This ensures that clicking the "CRM" brand logo/text will now redirect users to the root URL of the application.

How to Test
Pull this branch and run the application locally.

Navigate to any page other than the home page (e.g., /add_client)

Click on the "CRM" text/logo in the top-left corner of the navigation bar.

Expected result: You should be redirected to the application's home page (/).

